### PR TITLE
Sécurisation des identifiants de l'API REST

### DIFF
--- a/MediaTekDocuments/App.config
+++ b/MediaTekDocuments/App.config
@@ -2,6 +2,10 @@
 <configuration>
     <configSections>
     </configSections>
+    <connectionStrings>
+        <add name="MediaTekDocuments.RestApiUserPassword"
+             connectionString="admin:adminpwd" />
+    </connectionStrings>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>

--- a/MediaTekDocuments/dal/Access.cs
+++ b/MediaTekDocuments/dal/Access.cs
@@ -20,6 +20,10 @@ namespace MediaTekDocuments.dal
         /// </summary>
         private static readonly string uriApi = "http://localhost/rest_mediatekdocuments/";
         /// <summary>
+        /// Nom de la chaine de connexion utilisée pour s'authentifier auprès de l'API REST
+        /// </summary>
+        private const string connectionStringName = "MediaTekDocuments.RestApiUserPassword";
+        /// <summary>
         /// instance unique de la classe
         /// </summary>
         private static Access instance = null;
@@ -43,6 +47,16 @@ namespace MediaTekDocuments.dal
         /// méthode HTTP pour delete
         /// </summary>
         private const string DELETE = "DELETE";
+        
+        /// <summary>
+        /// Récupération d'une chaîne de connexion identifiée par son nom
+        /// </summary>
+        /// <param name="name">Le nom complet de la chaine de connexion</param>
+        /// <returns>La chaine de connexion demandée</returns>
+        private static string GetConnectionString(string name)
+        {
+            return ConfigurationManager.ConnectionStrings[name]?.ConnectionString;
+        }
 
         /// <summary>
         /// Méthode privée pour créer un singleton
@@ -53,7 +67,7 @@ namespace MediaTekDocuments.dal
             String authenticationString;
             try
             {
-                authenticationString = "admin:adminpwd";
+                authenticationString = GetConnectionString(connectionStringName);
                 api = ApiRest.GetInstance(uriApi, authenticationString);
             }
             catch (Exception e)


### PR DESCRIPTION
Ce commit sécurise les identifiants de l'API REST en les enlevant du fichier Access.cs et en les mettant dans le fichier de configuration App.config. Les identifiants sont ensuite récupérés depuis la classe ConfigurationManager.
Lors du déploiement de l'application, il sera alors possible de modifier les identifiants en modifiant la chaine de connexion présente dans le fichier MediaTekDocuments.exe.config qui est dans le même dossier que l'éxécutable.

Resolves #7.